### PR TITLE
start fundraising link to signin/dashboard page

### DIFF
--- a/src/app/fundraisers/[slug]/page.tsx
+++ b/src/app/fundraisers/[slug]/page.tsx
@@ -13,6 +13,7 @@ import {
   PublicTimelineMilestone,
   PublicTimelineMilestoneList,
 } from "@/components/fundraisers/public-timeline-milestone-list";
+import { SignedIn, SignedOut } from "@clerk/nextjs";
 
 interface Fundraiser {
   id: string;
@@ -386,11 +387,21 @@ export default function PublicFundraiserPage() {
                     Create your own fundraiser and start raising money for
                     causes you care about.
                   </p>
-                  <Link href="/app/fundraisers/create">
-                    <Button variant="outline" size="sm" className="w-full">
-                      Start Fundraising
-                    </Button>
-                  </Link>
+
+                  <SignedIn>
+                    <Link href="/app/dashboard">
+                      <Button variant="outline" size="sm" className="w-full">
+                        Start Fundraising
+                      </Button>
+                    </Link>
+                  </SignedIn>
+                  <SignedOut>
+                    <Link href="/signin">
+                      <Button variant="outline" size="sm" className="w-full">
+                        Start Fundraising
+                      </Button>
+                    </Link>
+                  </SignedOut>
                 </div>
 
                 {/* Details */}


### PR DESCRIPTION
# Update "Create Your Fundraiser / Start Fundraising" Link

## Description
This PR updates the **"Create Your Fundraiser" / "Start Fundraising"** call-to-action link to point to the `/signin` page.

## Changes
- Updated link destination for:
  - **Create Your Fundraiser**
  - **Start Fundraising**
- Ensured navigation redirects unauthenticated users to the `/signin` page and `/app/dashboard` page when user is signed in.

## Testing Notes
- Verify that clicking **"Create Your Fundraiser"** navigates to `/signin` or `/app/dashboard .
- Verify that clicking **"Start Fundraising"** navigates to `/signin` or `/app/dashboard`.

