### PR TITLE
"Already have an account? Sign In" shows

### DIFF
--- a/src/app/signin/[[...rest]]/page.tsx
+++ b/src/app/signin/[[...rest]]/page.tsx
@@ -3,7 +3,7 @@ import { SignIn } from "@clerk/nextjs";
 
 export default function SignInPage() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4">
+    <div className="h-[calc(100vh-75px)] flex flex-col items-center justify-center bg-background px-4">
       <SignIn signUpUrl="/signup" />
     </div>
   );

--- a/src/app/signup/[[...rest]]/page.tsx
+++ b/src/app/signup/[[...rest]]/page.tsx
@@ -3,7 +3,7 @@ import { SignUp } from "@clerk/nextjs";
 
 export default function SignUpPage() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4">
+    <div className="min-h-[calc(100vh-75px)] flex flex-col items-center justify-center bg-background px-4">
       <div className="p-8 flex flex-col gap-5 items-center">
         <SignUp signInUrl="/signin" />
       </div>


### PR DESCRIPTION
# Fix: "Already have an account? Sign In" showing after successful registration

## Description
This PR fixes an issue where the **"Already have an account? Sign In"** label incorrectly appears after a user successfully signs up.

## Steps to Reproduce (Before Fix)
1. Go to the **Home Page**.
2. Click the **Sign Up** button.
3. Fill in the registration form and submit.
4. After successful registration, the **"Already have an account? Sign In"** label is still shown.

## Fix
- Removed the **"Already have an account? Sign In"**  and **"Don’t have an account? Sign up"** label
- Ensured this label only appears on the **Sign Up** and **Sign In**  form before submission.


