### PR TITLE
Team Switcher Shows "Name's Group" instead of "Personal Account"

### DIFF
--- a/src/components/ui/team-switcher.tsx
+++ b/src/components/ui/team-switcher.tsx
@@ -63,7 +63,9 @@ export function TeamSwitcher() {
             aria-expanded={open}
             className="w-[200px] justify-between"
           >
-            {selectedAccount.name}
+            {selectedAccount.type === "individual"
+              ? "Personal Account"
+              : selectedAccount.name}
             <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>


### PR DESCRIPTION
# Team Switcher Shows "Name's Group" Instead of "Personal Account"

## Description
This PR fixes a UI inconsistency in the **Team Switcher** component where it initially displays `"{FirstName} {LastName}'s Group"` instead of `"Personal Account"` for individual users.

## Steps to Reproduce
1. Go to the **Home Page**.
2. Click the **Sign Up** button.
3. Complete and submit the registration form.
4. After redirection to the **Dashboard**, check the **Team Switcher**.

### Current Behavior
- The selected option displays: `"{FirstName} {LastName}'s Group"`  
- The dropdown correctly includes `"Personal Account"` as the label.

### Expected Behavior
- The **initial display value** should be `"Personal Account"` for individual groups (type = `individual`), matching the dropdown option.

## Fix
- Applied a conditional check for individual group types.
- Ensured the label for the current group shows `"Personal Account"` instead of the auto-generated group name.

## Testing Notes
- Sign up and get redirected to the dashboard.
- Confirm that the **Team Switcher** displays `"Personal Account"` immediately.
- Open the dropdown and ensure the option still reads `"Personal Account"`.
