### PR TITLE
Team Switcher dropdown overflow

### DIFF
--- a/src/components/ui/team-switcher.tsx
+++ b/src/components/ui/team-switcher.tsx
@@ -61,7 +61,7 @@ export function TeamSwitcher() {
             variant="outline"
             role="combobox"
             aria-expanded={open}
-            className="w-[200px] justify-between"
+            className="min-w-[200px] justify-between"
           >
             {selectedAccount.name}
             <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />


### PR DESCRIPTION
# Fix: Team Switcher Dropdown Overflow

## Description
This PR addresses a UI issue where the **Team Switcher** dropdown content would overflow or be clipped due to a fixed width.

## Fix
- Replaced the **fixed width** of the dropdown with a **`min-width`**.
- Allows the dropdown to expand based on content length, preventing label clipping or overflow.

## Testing Notes
- Open the **Team Switcher**.
- Verify that long group names or labels no longer overflow or get cut off.
- Ensure the dropdown remains visually aligned and functional across screen sizes.
